### PR TITLE
getXBubble testability refactoring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,9 +23,8 @@ MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 PMFRGMPIExt = ["MPI"]
 
 [extras]
-JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "MPI", "JLD2"]
+test = ["Test", "MPI"]

--- a/ext/PMFRGMPIExt/Flowequation_Dense.jl
+++ b/ext/PMFRGMPIExt/Flowequation_Dense.jl
@@ -2,8 +2,15 @@ using PMFRG, MPI, TimerOutputs
 include("mpi/MPI_Detail.jl")
 import .MPI_Detail
 
-function PMFRG.getXBubble!(Workspace::PMFRG.PMFRGWorkspace, Lam, ::PMFRG.UseMPI)
-    Par = Workspace.Par
+function PMFRG.getXBubble!(
+    X::PMFRG.BubbleType,
+    State::PMFRG.StateType,
+    Deriv::PMFRG.StateType,
+    Par::PMFRG.PMFRGParams,
+    Buffer,
+    Lam,
+    ::PMFRG.UseMPI,
+)
     (; N, np_vec) = Par.NumericalParams
 
     if MPI.Initialized()
@@ -24,14 +31,16 @@ function PMFRG.getXBubble!(Workspace::PMFRG.PMFRGWorkspace, Lam, ::PMFRG.UseMPI)
         iurange_full = 1:N
         isrange, itrange, _ = all_ranges[rank+1]
         @timeit_debug "partition" PMFRG.getXBubblePartition!(
-            Workspace,
+            X,
+            State,
+            Deriv,
+            Par,
+            Buffer,
             Lam,
             isrange,
             itrange,
             iurange_full,
         )
-
-        (; X) = Workspace
 
 
         @timeit_debug "communication" for root = 0:(nranks-1)
@@ -65,6 +74,6 @@ function PMFRG.getXBubble!(Workspace::PMFRG.PMFRGWorkspace, Lam, ::PMFRG.UseMPI)
         end
     else
         @warn "MPI package used but not initialized" maxlog = 1
-        PMFRG.getXBubblePartition!(Workspace, Lam, 1:N, 1:N, 1:N)
+        PMFRG.getXBubblePartition!(X, State, Deriv, Par, Buffer, Lam, 1:N, 1:N, 1:N)
     end
 end

--- a/ext/PMFRGMPIExt/Flowequation_Dense.jl
+++ b/ext/PMFRGMPIExt/Flowequation_Dense.jl
@@ -2,15 +2,8 @@ using PMFRG, MPI, TimerOutputs
 include("mpi/MPI_Detail.jl")
 import .MPI_Detail
 
-function PMFRG.getXBubble!(
-    X::PMFRG.BubbleType,
-    State::PMFRG.StateType,
-    Deriv::PMFRG.StateType,
-    Par::PMFRG.PMFRGParams,
-    Buffer,
-    Lam,
-    ::PMFRG.UseMPI,
-)
+function PMFRG.getXBubble!(Workspace, Lam, ::PMFRG.UseMPI)
+    (; X, Par) = Workspace
     (; N, np_vec) = Par.NumericalParams
 
     if MPI.Initialized()
@@ -32,10 +25,10 @@ function PMFRG.getXBubble!(
         isrange, itrange, _ = all_ranges[rank+1]
         @timeit_debug "partition" PMFRG.getXBubblePartition!(
             X,
-            State,
-            Deriv,
+            Workspace.State,
+            Workspace.Deriv,
             Par,
-            Buffer,
+            Workspace.Buffer,
             Lam,
             isrange,
             itrange,

--- a/ext/PMFRGMPIExt/test/RegressionTests/PMFRG.getXBubble.data
+++ b/ext/PMFRGMPIExt/test/RegressionTests/PMFRG.getXBubble.data
@@ -1,1 +1,0 @@
-../../../../test/RegressionTests/PMFRG.getXBubble.data

--- a/ext/PMFRGMPIExt/test/RegressionTests/PMFRG.getXBubbleMPI.jl
+++ b/ext/PMFRGMPIExt/test/RegressionTests/PMFRG.getXBubbleMPI.jl
@@ -5,24 +5,33 @@
 #
 
 using Test
-using JLD2
+using HDF5
 using MPI
 using PMFRG
 using SpinFRGLattices.SquareLattice
 
 thisdir = dirname(@__FILE__)
-data = load_object(joinpath(thisdir, "PMFRG.getXBubble.data"))
-
+non_mpi_regrtest_location = "../../../../test/RegressionTests"
 include("../../../../test/RegressionTests/PMFRG.getXBubble.common.jl")
+
+
+fname = joinpath(thisdir, non_mpi_regrtest_location, "PMFRG.getXBubble.data.h5")
+h5file = h5open(fname, "r")
 
 MPI.Init()
 
 @testset verbose = true "Tests for getXBubble!" begin
-    @testset for i = 1:length(data["return_value"])
-        workspace, lam, _ = (data["arguments"])[i]
-        workspace_post_exp, lam_post_exp, _ = (data["arguments_post"])[i]
-        PMFRG.getXBubble!(workspace, lam, UseMPI())
-        @test compare_arguments_post((workspace_post_exp, lam_post_exp), (workspace, lam))
+    ncases = read(h5file["Ncases"])
+    @testset for i = 1:ncases
+        (; X, State, Deriv, Lam) = h5deserialize(h5file, "arguments", i)
+        X0 = X
+
+        Par = generate_test_params()
+        (; Buffs) = PMFRG.AllocateSetup(Par)
+        PMFRG.getXBubble!(X0, State, Deriv, Par, Buffs, Lam, UseMPI())
+
+        (; X) = h5deserialize(h5file, "arguments_post", i)
+        @test compare_arguments_post(X, X0)
     end
 end
 

--- a/ext/PMFRGMPIExt/test/RegressionTests/PMFRG.getXBubbleMPI.jl
+++ b/ext/PMFRGMPIExt/test/RegressionTests/PMFRG.getXBubbleMPI.jl
@@ -28,7 +28,9 @@ MPI.Init()
 
         Par = generate_test_params()
         (; Buffs) = PMFRG.AllocateSetup(Par)
-        PMFRG.getXBubble!(X0, State, Deriv, Par, Buffs, Lam, UseMPI())
+        Workspace = PMFRG.OneLoopWorkspace(State, Deriv, X0, Buffs, Par)
+
+        PMFRG.getXBubble!(Workspace, Lam, UseMPI())
 
         (; X) = h5deserialize(h5file, "arguments_post", i)
         @test compare_arguments_post(X, X0)

--- a/src/Flowequations_Dense.jl
+++ b/src/Flowequations_Dense.jl
@@ -6,7 +6,15 @@ function getDeriv!(Deriv, State, setup, Lam)
         @timeit_debug "getDFint!" getDFint!(Workspace, Lam)
         @timeit_debug "get_Self_Energy!" get_Self_Energy!(Workspace, Lam)
 
-        @timeit_debug "getXBubble!" getXBubble!(Workspace, Lam, setup.ParallelizationScheme)
+        @timeit_debug "getXBubble!" getXBubble!(
+            X,
+            Workspace.State,
+            Workspace.Deriv,
+            Par,
+            Buffs,
+            Lam,
+            setup.ParallelizationScheme,
+        )
 
         @timeit_debug "symmetrizeBubble!" symmetrizeBubble!(Workspace.X, Par)
 

--- a/src/Flowequations_Dense.jl
+++ b/src/Flowequations_Dense.jl
@@ -119,12 +119,17 @@ function getXBubble!(
 end
 
 """writing to X and XTilde in Workspace, computes bubble diagrams within a range of frequencies given by isrange, itrange and iurange"""
-function getXBubblePartition!(X::BubbleType,
-                              State::StateType,
-                              Deriv::StateType,
-                              Par,
-                              Buffers,
-                              Lam, isrange, itrange, iurange)
+function getXBubblePartition!(
+    X::BubbleType,
+    State::StateType,
+    Deriv::StateType,
+    Par,
+    Buffers,
+    Lam,
+    isrange,
+    itrange,
+    iurange,
+)
     (; T, N, lenIntw, np_vec) = Par.NumericalParams
     PropsBuffers = Buffers.Props
     VertexBuffers = Buffers.Vertex

--- a/src/Flowequations_Dense.jl
+++ b/src/Flowequations_Dense.jl
@@ -6,15 +6,7 @@ function getDeriv!(Deriv, State, setup, Lam)
         @timeit_debug "getDFint!" getDFint!(Workspace, Lam)
         @timeit_debug "get_Self_Energy!" get_Self_Energy!(Workspace, Lam)
 
-        @timeit_debug "getXBubble!" getXBubble!(
-            X,
-            Workspace.State,
-            Workspace.Deriv,
-            Par,
-            Buffs,
-            Lam,
-            setup.ParallelizationScheme,
-        )
+        @timeit_debug "getXBubble!" getXBubble!(Workspace, Lam, setup.ParallelizationScheme)
 
         @timeit_debug "symmetrizeBubble!" symmetrizeBubble!(Workspace.X, Par)
 
@@ -113,17 +105,19 @@ function get_Self_Energy!(Workspace::PMFRGWorkspace, Lam)
 end
 # @inline getXBubble!(Workspace::PMFRGWorkspace,Lam) = getXBubble!(Workspace,Lam,Val(Workspace.Par.System.NUnique)) 
 
-function getXBubble!(
-    X::BubbleType,
-    State::StateType,
-    Deriv::StateType,
-    Par::PMFRGParams,
-    Buffer,
-    Lam,
-    ParallelizationScheme::MultiThreaded = MultiThreaded(),
-)
-    (; N) = Par.NumericalParams
-    getXBubblePartition!(X, State, Deriv, Par, Buffer, Lam, 1:N, 1:N, 1:N)
+function getXBubble!(Workspace, Lam, ParallelizationScheme::MultiThreaded = MultiThreaded())
+    (; N) = Workspace.Par.NumericalParams
+    getXBubblePartition!(
+        Workspace.X,
+        Workspace.State,
+        Workspace.Deriv,
+        Workspace.Par,
+        Workspace.Buffer,
+        Lam,
+        1:N,
+        1:N,
+        1:N,
+    )
 end
 
 """writing to X and XTilde in Workspace, computes bubble diagrams within a range of frequencies given by isrange, itrange and iurange"""

--- a/src/TwoLoop/Flowequations.jl
+++ b/src/TwoLoop/Flowequations.jl
@@ -4,7 +4,7 @@ function getDerivTwoLoop!(Deriv, State, setup, Lam)
 
     getDFint!(Workspace, Lam)
     get_Self_Energy!(Workspace, Lam)
-    getXBubble!(Workspace, Lam)
+    getXBubble!(X, Workspace.State, Workspace.Deriv, Par, Buffs, Lam)
     symmetrizeBubble!(Workspace.X, Par)
 
     addToVertexFromBubble!(Workspace.Deriv.Γ, Workspace.X)

--- a/src/TwoLoop/Flowequations.jl
+++ b/src/TwoLoop/Flowequations.jl
@@ -4,7 +4,7 @@ function getDerivTwoLoop!(Deriv, State, setup, Lam)
 
     getDFint!(Workspace, Lam)
     get_Self_Energy!(Workspace, Lam)
-    getXBubble!(X, Workspace.State, Workspace.Deriv, Par, Buffs, Lam)
+    getXBubble!(Workspace, Lam)
     symmetrizeBubble!(Workspace.X, Par)
 
     addToVertexFromBubble!(Workspace.Deriv.Γ, Workspace.X)

--- a/test/RegressionTests/.gitattributes
+++ b/test/RegressionTests/.gitattributes
@@ -1,1 +1,2 @@
 *.data filter=lfs diff=lfs merge=lfs -text
+*.data.h5 filter=lfs diff=lfs merge=lfs -text

--- a/test/RegressionTests/PMFRG.getXBubble.common.jl
+++ b/test/RegressionTests/PMFRG.getXBubble.common.jl
@@ -31,13 +31,8 @@ end
 
 using SpinFRGLattices.SquareLattice
 function generate_test_params()
-System = getSquareLattice(4, [1.0,0.1])
-Params(
-    System,
-    OneLoop(),
-    T = 0.5,
-    N = 5,
-    accuracy = 1e-3,)
+    System = getSquareLattice(4, [1.0, 0.1])
+    Params(System, OneLoop(), T = 0.5, N = 5, accuracy = 1e-3)
 end
 
 

--- a/test/RegressionTests/PMFRG.getXBubble.common.jl
+++ b/test/RegressionTests/PMFRG.getXBubble.common.jl
@@ -1,10 +1,4 @@
-function compare_arguments_post(args_post_exp, args_post)
-    workspace_post_exp, _ = args_post_exp
-    workspace_post, _ = args_post
-
-    Xexp = workspace_post_exp.X
-    X = workspace_post.X
-
+function compare_arguments_post(Xexp, X)
     result = true
     for field in fieldnames(typeof(X))
         val = getfield(X, field)

--- a/test/RegressionTests/PMFRG.getXBubble.common.jl
+++ b/test/RegressionTests/PMFRG.getXBubble.common.jl
@@ -28,3 +28,127 @@ function compare_arguments_post(Xexp, X)
     end
     result
 end
+
+using SpinFRGLattices.SquareLattice
+function generate_test_params()
+System = getSquareLattice(4, [1.0,0.1])
+Params(
+    System,
+    OneLoop(),
+    T = 0.5,
+    N = 5,
+    accuracy = 1e-3,)
+end
+
+
+
+
+using HDF5
+using H5Zblosc
+function h5deserialize(f::HDF5.File, root::String, id::Int)
+    (
+        X = PMFRG.BubbleType(
+            read(f["$root/$id/X/a"]),
+            read(f["$root/$id/X/b"]),
+            read(f["$root/$id/X/c"]),
+            read(f["$root/$id/X/Ta"]),
+            read(f["$root/$id/X/Tb"]),
+            read(f["$root/$id/X/Tc"]),
+            read(f["$root/$id/X/Td"]),
+        ),
+        State = PMFRG.StateType(
+            read(f["$root/$id/State/f_int"]),
+            read(f["$root/$id/State/γ"]),
+            PMFRG.VertexType(
+                read(f["$root/$id/State/Γ/a"]),
+                read(f["$root/$id/State/Γ/b"]),
+                read(f["$root/$id/State/Γ/c"]),
+            ),
+        ),
+        Deriv = PMFRG.StateType(
+            read(f["$root/$id/Deriv/f_int"]),
+            read(f["$root/$id/Deriv/γ"]),
+            PMFRG.VertexType(
+                read(f["$root/$id/Deriv/Γ/a"]),
+                read(f["$root/$id/Deriv/Γ/b"]),
+                read(f["$root/$id/Deriv/Γ/c"]),
+            ),
+        ),
+        Lam = read(f["$root/$id/Lam"]),
+    )
+end
+
+"""Function that can be used to store X,State,Deriv and Lam
+(the non-trivially-constructible arguments of getXBubble!)
+in a HDF5 file, so that h5deserialize can read them properly"""
+function h5serialize!(
+    f::HDF5.File,
+    root::String,
+    X::PMFRG.BubbleType,
+    S::PMFRG.StateType,
+    D::PMFRG.StateType,
+    Lam::Float64,
+    id::Int,
+)
+    # X
+    f["$root/$id/X/a", blosc = 9] = X.a
+    f["$root/$id/X/b", blosc = 9] = X.b
+    f["$root/$id/X/c", blosc = 9] = X.c
+    f["$root/$id/X/Ta", blosc = 9] = X.Ta
+    f["$root/$id/X/Tb", blosc = 9] = X.Tb
+    f["$root/$id/X/Tc", blosc = 9] = X.Tc
+    f["$root/$id/X/Td", blosc = 9] = X.Td
+
+    # S
+    f["$root/$id/State/f_int", blosc = 9] = S.f_int
+    f["$root/$id/State/γ", blosc = 9] = S.γ
+    f["$root/$id/State/Γ/a", blosc = 9] = S.Γ.a
+    f["$root/$id/State/Γ/b", blosc = 9] = S.Γ.b
+    f["$root/$id/State/Γ/c", blosc = 9] = S.Γ.c
+
+    # D
+    f["$root/$id/Deriv/f_int", blosc = 9] = D.f_int
+    f["$root/$id/Deriv/γ", blosc = 9] = D.γ
+    f["$root/$id/Deriv/Γ/a", blosc = 9] = D.Γ.a
+    f["$root/$id/Deriv/Γ/b", blosc = 9] = D.Γ.b
+    f["$root/$id/Deriv/Γ/c", blosc = 9] = D.Γ.c
+
+
+    # Lam
+    f["$root/$id/Lam"] = Lam
+end
+
+
+"""This function has only been used
+to convert the existing serialized data
+into HDF5.
+It is kept here only for reference"""
+function convert_jld2_to_hdf5(data, filename)
+
+    println("Saving to hdf5")
+    f = h5open(filename, "w")
+    try
+        ncases = length(data["return_value"])
+        f["Ncases"] = ncases
+        for i = 1:ncases
+            workspace, lam, _ = (data["arguments"])[i]
+            workspace_post_exp, _, _ = (data["arguments_post"])[i]
+
+            let X, State, Deriv
+                (; X, State, Deriv) = workspace
+                h5serialize!(f, "arguments", X, State, Deriv, lam, i)
+            end
+
+
+            let X, State, Deriv
+                (; X, State, Deriv) = workspace_post_exp
+                h5serialize!(f, "arguments_post", X, State, Deriv, lam, i)
+            end
+
+
+        end
+    finally
+        close(f)
+    end
+
+end

--- a/test/RegressionTests/PMFRG.getXBubble.data
+++ b/test/RegressionTests/PMFRG.getXBubble.data
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d88d9f9ec2abcfba2c866f2c0896a2111d10a44379e6a94f04251701f9614af1
-size 2293655

--- a/test/RegressionTests/PMFRG.getXBubble.data.h5
+++ b/test/RegressionTests/PMFRG.getXBubble.data.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1b567646bb900233c3f222e2d8bd06b9bc757e2f24a5d64dd1b98320d1c1958
+size 1510568

--- a/test/RegressionTests/PMFRG.getXBubble.jl
+++ b/test/RegressionTests/PMFRG.getXBubble.jl
@@ -25,7 +25,8 @@ function test_getXBubble()
                 Par = generate_test_params()
 
                 (; Buffs) = PMFRG.AllocateSetup(Par)
-                PMFRG.getXBubble!(X0, State, Deriv, Par, Buffs, Lam, PMFRG.MultiThreaded())
+                Workspace = PMFRG.OneLoopWorkspace(State, Deriv, X0, Buffs, Par)
+                PMFRG.getXBubble!(Workspace, Lam, PMFRG.MultiThreaded())
 
                 (; X) = h5deserialize(h5file, "arguments_post", i)
                 @test compare_arguments_post(X, X0)

--- a/test/RegressionTests/PMFRG.getXBubble.jl
+++ b/test/RegressionTests/PMFRG.getXBubble.jl
@@ -3,11 +3,11 @@ using SpinFRGLattices.SquareLattice
 using Test
 using JLD2
 thisdir = dirname(@__FILE__)
-data = load_object(joinpath(thisdir, "PMFRG.getXBubble.data"))
 
 include("PMFRG.getXBubble.common.jl")
 
 function test_getXBubble()
+    data = load_object(joinpath(thisdir, "PMFRG.getXBubble.data"))
     @testset verbose = true "Tests for getXBubble!" begin
         @testset for i = 1:length(data["return_value"])
             workspace, lam, _ = (data["arguments"])[i]

--- a/test/RegressionTests/PMFRG.getXBubble.jl
+++ b/test/RegressionTests/PMFRG.getXBubble.jl
@@ -11,12 +11,20 @@ function test_getXBubble()
     @testset verbose = true "Tests for getXBubble!" begin
         @testset for i = 1:length(data["return_value"])
             workspace, lam, _ = (data["arguments"])[i]
-            workspace_post_exp, lam_post_exp, _ = (data["arguments_post"])[i]
-            PMFRG.getXBubble!(workspace, lam)
-            @test compare_arguments_post(
-                (workspace_post_exp, lam_post_exp),
-                (workspace, lam),
-            )
+
+            (;X,State,Deriv) = workspace
+            Par = generate_test_params()
+
+            (;Buffs) = PMFRG.AllocateSetup(Par)
+            workspace_post_exp, _, _ = (data["arguments_post"])[i]
+            PMFRG.getXBubble!(X,
+                              State,
+                              Deriv,
+                              Par,
+                              Buffs,
+                              lam,
+                              PMFRG.MultiThreaded())
+            @test compare_arguments_post(workspace_post_exp.X, X)
         end
     end
 end

--- a/test/RegressionTests/PMFRG.getXBubble.jl
+++ b/test/RegressionTests/PMFRG.getXBubble.jl
@@ -1,7 +1,7 @@
 using PMFRG
 using SpinFRGLattices.SquareLattice
 using Test
-using JLD2
+using HDF5
 thisdir = dirname(@__FILE__)
 
 include("PMFRG.getXBubble.common.jl")
@@ -12,7 +12,7 @@ function test_getXBubble()
     h5file = h5open(fname, "r")
     try
         @testset verbose = true "Tests for getXBubble!" begin
-            ncases =  read(h5file["Ncases"])
+            ncases = read(h5file["Ncases"])
             @testset for i = 1:ncases
 
                 (; X, State, Deriv, Lam) = h5deserialize(h5file, "arguments", i)

--- a/test/UnitTests/TypeStability.jl
+++ b/test/UnitTests/TypeStability.jl
@@ -23,11 +23,11 @@ function test_OneLoopAllocations(Par = Params(getPolymer(2)))
     put!(WS.Buffer.Vertex, VBuff)
 end
 function test_OneLoopAllocations(Par, WS, SProps, VBuff)
-    PMFRG.addX!(WS, 1, 1, 2, 2, SProps, VBuff) # compile functions
-    PMFRG.addXTilde!(WS, 1, 1, 2, 2, SProps) # compile functions
+    PMFRG.addX!(WS.X, WS.State, WS.Par, 1, 1, 2, 2, SProps, VBuff) # compile functions
+    PMFRG.addXTilde!(WS.X, WS.State, WS.Par, 1, 1, 2, 2, SProps) # compile functions
 
-    aX = @allocated PMFRG.addX!(WS, 1, 1, 2, 2, SProps, VBuff)
-    aXT = @allocated PMFRG.addXTilde!(WS, 1, 1, 2, 2, SProps)
+    aX = @allocated PMFRG.addX!(WS.X, WS.State, WS.Par, 1, 1, 2, 2, SProps, VBuff)
+    aXT = @allocated PMFRG.addXTilde!(WS.X, WS.State, WS.Par, 1, 1, 2, 2, SProps)
     test_TypeStability(Par, WS, aX, aXT)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,10 +8,10 @@ include("RegressionTests/PMFRG.getXBubble.jl")
 
 ##
 @testset verbose = true "PMFRG tests" begin
-    test_mpi()
     testOneLoop(Obsacc)
     testTwoLoop(Obsacc)
     testParquet()
     test_IO()
     test_getXBubble()
+    test_mpi()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,10 +8,10 @@ include("RegressionTests/PMFRG.getXBubble.jl")
 
 ##
 @testset verbose = true "PMFRG tests" begin
+    test_mpi()
+    test_getXBubble()
     testOneLoop(Obsacc)
     testTwoLoop(Obsacc)
     testParquet()
     test_IO()
-    test_getXBubble()
-    test_mpi()
 end


### PR DESCRIPTION
Fixes https://github.com/NilsNiggemann/PMFRG.jl/issues/10.

1. Change getXBubblePartition! to have the signature suggested:
```
    function getXBubblePartition!(X,State,Deriv,Lam,Buffer,Par, isrange,  itrange,  iurange)
       [...]
    end
```
Also in this case, callees and their tests have been changed accordingly, removing the need to have a Workspace parameter. `getXBubble!` has been left as before.
2. Reworked the regression test case data, now stored in HDF5 format, compressed, and amounting to only 1.5MB. Logic of the test case has been changed accordingly.